### PR TITLE
[EVAKA-HOTFIX] Better error logs for failed downloads

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func downloadObject(downloader *s3manager.Downloader, wg *sync.WaitGroup, detail
 		Bucket: aws.String(details.Bucket),
 		Key:    aws.String(details.Key),
 	})
-	check(err, "Unable to download item %q", details.TargetFile)
+	check(err, "Unable to download item %q from %q to destination %q", details.Key, details.Bucket, details.TargetFile)
 }
 
 func createFile(targetFile string) *os.File {


### PR DESCRIPTION
#### Summary
- Instead of just logging the target filename, log the source key and bucket to be much more useful for debugging

#### Dependencies
None

#### Testing instructions
This one's a bit difficult to test without admin federation powers but I've tested this manually:

```
# Build locally
make build

# Assuming evaka-ai-srv's IAM role
aws-vault exec voltti-dev-ai-srv

# Test
./bin/s3downloader-linux-amd64 evaka-deployment-dev evaka-srv test
# Output:
# ...
# {"@timestamp":"2021-07-12T15:51:15+03:00","appBuild":"local","appCommit":"HEAD","appName":"","env":"local","exception":"Error","hostIp":"","logLevel":"error","message":"Unable to download item \"evaka-srv/trustStore.jks\" from \"evaka-deployment-dev\" to destination \"test/trustStore.jks\"","stackTrace":"AccessDenied: Access Denied\n\tstatus code: 403, request id: BS7DXF43C1BKVH53, host id: 2m8RjGRKh1TW/lBHJTf54JS6Q5G/cOFvqigdAmuOO9r8JyPHwX0fIK1pcY+PZ7rZH9o4TLXqIAY=","type":"app-misc","userIdHash":"","version":"1"}
```

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] The code is consistent with the existing code base
- [x] The change has been tested locally
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] The change has been tested locally
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```
